### PR TITLE
fix(docker): apply PR #6 review comments (MongoDB 8.0, healthchecks, security)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ NODE_ENV=development
 **Frontend `.env` example:**
 
 ```env
-REACT_APP_API_URL=http://localhost:5000/api
+VITE_API_URL=http://localhost:5000/api
 ```
 
 ### 3. Install dependencies
@@ -160,10 +160,10 @@ npm run dev
 
 ```bash
 cd client
-npm start
+npm run dev
 ```
 
-(Default: [http://localhost:3000](http://localhost:3000))
+(Default: [http://localhost:5173](http://localhost:5173))
 
 ### 5. Run with Docker (Development Mode)
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,17 +3,25 @@ version: '3.8'
 services:
   # MongoDB Database
   mongodb:
-    image: mongo:7
+    image: mongo:8.0
     container_name: planit-mongodb-dev
     restart: unless-stopped
     ports:
       - '27017:27017'
     environment:
+      # WARNING: The following credentials are for local development only.
+      # DO NOT use these credentials in production or on any network-accessible environment.
+      # Change the username and password if exposing this environment to a network.
       MONGO_INITDB_ROOT_USERNAME: admin
       MONGO_INITDB_ROOT_PASSWORD: admin123
       MONGO_INITDB_DATABASE: planit
     volumes:
       - mongodb_data:/data/db
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - planit-network
 
@@ -29,13 +37,18 @@ services:
     environment:
       NODE_ENV: development
       PORT: 5000
+      # WARNING: This JWT secret and MongoDB credentials are for development only.
+      # DO NOT use these values in production or any shared environment!
+      # You MUST set strong, unique secrets before deploying to production.
+      # Using these keys in production will compromise authentication security.
       MONGO_URI: mongodb://admin:admin123@mongodb:27017/planit?authSource=admin
       JWT_SECRET: dev_jwt_secret_change_in_production
     volumes:
       - ./server:/app
       - /app/node_modules
     depends_on:
-      - mongodb
+      mongodb:
+        condition: service_healthy
     networks:
       - planit-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,22 @@ version: '3.8'
 services:
   # MongoDB Database
   mongodb:
-    image: mongo:7
+    image: mongo:8.0
     container_name: planit-mongodb
     restart: always
     environment:
-      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USERNAME:-admin}
-      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD:-admin123}
+      # IMPORTANT: Set MONGO_USERNAME and MONGO_PASSWORD environment variables before deployment.
+      # Never use default credentials in production!
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
       MONGO_INITDB_DATABASE: planit
     volumes:
       - mongodb_data:/data/db
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - planit-network
 
@@ -27,10 +34,11 @@ services:
     environment:
       NODE_ENV: production
       PORT: 5000
-      MONGO_URI: ${MONGO_URI}
+      MONGO_URI: mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@mongodb:27017/planit?authSource=admin
       JWT_SECRET: ${JWT_SECRET}
     depends_on:
-      - mongodb
+      mongodb:
+        condition: service_healthy
     networks:
       - planit-network
 
@@ -43,6 +51,11 @@ services:
     restart: always
     ports:
       - '80:80'
+    environment:
+      # The API URL should be set based on your deployment configuration
+      # For local Docker network: http://server:5000/api
+      # For production: set to your actual backend URL
+      VITE_API_URL: ${VITE_API_URL:-http://server:5000/api}
     depends_on:
       - server
     networks:


### PR DESCRIPTION
## Description

This PR addresses all 11 review comments from PR #6 (Copilot review).

## Changes

### Docker Compose (Production)
- ✅ Updated MongoDB version from 7 to **8.0**
- ✅ Added healthcheck using `mongosh` to ensure MongoDB is ready before dependent services start
- ✅ **Removed default credentials** - now requires explicit `MONGO_USERNAME` and `MONGO_PASSWORD` environment variables
- ✅ Added security warning comments for production deployment
- ✅ Changed `depends_on` to use `condition: service_healthy`
- ✅ Added `VITE_API_URL` environment variable to client service
- ✅ Fixed `MONGO_URI` to reference local MongoDB service

### Docker Compose (Development)
- ✅ Updated MongoDB version from 7 to **8.0**
- ✅ Added healthcheck using `mongosh`
- ✅ Added prominent **security warning comments** above dev credentials
- ✅ Changed `depends_on` to use `condition: service_healthy`

### README.md
- ✅ Fixed environment variables to use **Vite conventions** (`VITE_API_URL` instead of `REACT_APP_API_URL`)
- ✅ Updated run commands to use `npm run dev` instead of `npm start`
- ✅ Fixed port references from 3000 to **5173** (Vite default)

## Testing

- ✅ Validated `npm ci` for both server (456 packages) and client (429 packages)
- ✅ Validated `npm run build` for client (successful build: 455.69 KB)

## Related

- Closes review comments from PR #6
- Part of infrastructure setup phase