### PR TITLE
docs(readme): add CI/CD pipeline status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Planit
 
+[![CI/CD Pipeline](https://github.com/itsmardochee/Planit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/itsmardochee/Planit/actions/workflows/ci.yml)
+[![CI/CD Pipeline (dev)](https://github.com/itsmardochee/Planit/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/itsmardochee/Planit/actions/workflows/ci.yml)
+
 > "Plan your success, one board at a time." — *The Planit Team*
 
 **A Trello-like Web Application built with React, Node.js, and MongoDB**


### PR DESCRIPTION
## Changes

- ✅ Added CI/CD pipeline status badges for `main` and `dev` branches
- ✅ Badges link directly to workflow runs for transparency

## Context

Now that we have a working CI pipeline (PR #83), this adds visibility badges to the README as requested in issue #81.

## Notes

Coverage badges will be added in a future PR once we integrate a coverage provider (Codecov/Coveralls) and have actual test coverage to report.

Closes #81