### PR TITLE
chore(docker): Update to official MongoDB Community Server image

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   # MongoDB Database
   mongodb:
-    image: mongo:8.0
+    image: mongodb/mongodb-community-server:8.0-ubi8
     container_name: planit-mongodb-dev
     restart: unless-stopped
     ports:
@@ -14,7 +14,6 @@ services:
       # Change the username and password if exposing this environment to a network.
       MONGO_INITDB_ROOT_USERNAME: admin
       MONGO_INITDB_ROOT_PASSWORD: admin123
-      MONGO_INITDB_DATABASE: planit
     volumes:
       - mongodb_data:/data/db
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   # MongoDB Database
   mongodb:
-    image: mongo:8.0
+    image: mongodb/mongodb-community-server:8.0-ubi8
     container_name: planit-mongodb
     restart: always
     environment:
@@ -11,7 +11,6 @@ services:
       # Never use default credentials in production!
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_USERNAME}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
-      MONGO_INITDB_DATABASE: planit
     volumes:
       - mongodb_data:/data/db
     healthcheck:


### PR DESCRIPTION
## Description

Update MongoDB Docker images to use the official MongoDB Community Server image as per [official documentation](https://hub.docker.com/r/mongodb/mongodb-community-server).

## Changes

- ✅ Changed image from `mongo:8.0` to `mongodb/mongodb-community-server:8.0-ubi8`
- ✅ Removed `MONGO_INITDB_DATABASE: planit` (not required for Community Server)
- ✅ Applied to both `docker-compose.dev.yml` and `docker-compose.yml`
- ✅ Kept authentication variables (username/password) unchanged

## Rationale

Following MongoDB's official documentation recommendations for using the Community Server image instead of the generic `mongo` image.

## Testing

Can be verified by running:
```bash
docker-compose -f docker-compose.dev.yml up --build
```

Server should connect to MongoDB without authentication errors.