### PR TITLE
fix(docker): enable hot reload with nodemon legacy watch mode

### DIFF
--- a/server/nodemon.json
+++ b/server/nodemon.json
@@ -1,0 +1,7 @@
+{
+  "watch": ["src"],
+  "ext": "js,json",
+  "ignore": ["src/**/*.test.js", "node_modules"],
+  "legacyWatch": true,
+  "delay": 1000
+}

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
-    "dev": "nodemon src/index.js",
+    "dev": "nodemon --legacy-watch src/index.js",
     "lint": "npx eslint src/ && npx prettier --check \"src/**/*.{js,jsx,ts,tsx}\"",
     "lint:fix": "npx eslint src/ --fix && npx prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watchAll --verbose",


### PR DESCRIPTION
## Summary

Fix Docker hot reload functionality by enabling nodemon's legacy watch mode for proper file change detection in Docker volumes.

## Changes

- **Added `nodemon.json`** configuration file with:
  - `legacyWatch: true` for Docker volume compatibility
  - Watch only `src/` directory
  - Ignore test files and node_modules
  - 1 second delay for stability
  
- **Updated `package.json`** dev script:
  - Added `--legacy-watch` flag to nodemon command

## Problem Solved

Nodemon was not detecting file changes when running in Docker containers because the default file watching mechanism (inotify/fsevents) doesn't work properly with Docker volumes on some host systems. Legacy watch mode uses polling instead, which works reliably across all platforms.

## Testing

✅ Tested with `docker-compose -f docker-compose.dev.yml up --build`
✅ Verified hot reload by modifying files in `server/src/`
✅ Confirmed nodemon restarts automatically on file changes

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Code follows project conventions
- [x] Tested in Docker environment
- [x] No impact on production builds (only affects dev mode)