### PR TITLE
feat(card): Card CRUD implementation with TDD

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,6 +88,100 @@ test(board): add controller unit tests
 
 Branch naming: `feature/description`, `bugfix/description`, `hotfix/description`
 
+### Test-Driven Development (TDD)
+
+**Mandatory TDD approach for all features:**
+
+Planit follows strict **Test-Driven Development** (TDD) for all backend and frontend implementations. This ensures code quality, prevents regressions, and documents expected behavior.
+
+**Red-Green-Refactor Cycle:**
+
+1. **Red**: Write a failing test first that describes the desired behavior
+2. **Green**: Write minimal code to make the test pass
+3. **Refactor**: Improve code structure while keeping tests green
+
+**Backend TDD Workflow:**
+
+```bash
+# 1. Create test file (e.g., cardController.test.js)
+# 2. Write failing test
+describe('Card Controller', () => {
+  it('should create a card with valid data', async () => {
+    const res = await request(app)
+      .post('/api/lists/123/cards')
+      .send({ title: 'Test Card' });
+    expect(res.status).toBe(201);
+  });
+});
+
+# 3. Run test (should fail)
+npm test -- cardController.test.js
+
+# 4. Implement controller logic to pass test
+# 5. Run test again (should pass)
+# 6. Refactor if needed
+```
+
+**Frontend TDD Workflow:**
+
+```bash
+# 1. Create test file (e.g., CardModal.test.jsx)
+# 2. Write failing test
+describe('CardModal', () => {
+  it('renders card title input', () => {
+    render(<CardModal />);
+    expect(screen.getByLabelText('Card Title')).toBeInTheDocument();
+  });
+});
+
+# 3. Run test (should fail)
+npm test -- CardModal.test.jsx
+
+# 4. Implement component to pass test
+# 5. Run test again (should pass)
+# 6. Refactor if needed
+```
+
+**TDD Best Practices:**
+
+- **Never write production code without a failing test first**
+- **Write the simplest test first**, then add edge cases
+- **One test failure at a time** - fix before moving to next test
+- **Test behavior, not implementation** - tests should survive refactoring
+- **Mock external dependencies** (database, API calls) in unit tests
+- **Integration tests** verify full request/response cycle
+
+**Example TDD Session (Card Model):**
+
+```bash
+# Step 1: Write model test
+it('should require title field', async () => {
+  const card = new Card({ listId: '123' });
+  await expect(card.save()).rejects.toThrow();
+});
+
+# Step 2: Run test → FAILS (model doesn't exist yet)
+
+# Step 3: Create minimal Card model
+const cardSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  listId: { type: mongoose.Schema.Types.ObjectId, required: true }
+});
+
+# Step 4: Run test → PASSES
+
+# Step 5: Add more tests (position, description, etc.)
+# Step 6: Implement features to pass new tests
+```
+
+**CI Enforcement:**
+
+All PRs must have:
+
+- 100% test coverage for new code (enforced in reviews)
+- All tests passing (automated CI check)
+- No skipped/pending tests without justification
+
 ### Git Workflow
 
 **Branch Strategy (GitFlow):**

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+.vite

--- a/server/src/config/swagger.js
+++ b/server/src/config/swagger.js
@@ -351,6 +351,87 @@ const options = {
             },
           },
         },
+        Card: {
+          type: 'object',
+          required: ['title', 'listId', 'boardId', 'userId'],
+          properties: {
+            _id: {
+              type: 'string',
+              description: 'Card ID (auto-generated)',
+              example: '507f1f77bcf86cd799439011',
+            },
+            title: {
+              type: 'string',
+              maxLength: 200,
+              description: 'Card title',
+              example: 'Implement authentication',
+            },
+            description: {
+              type: 'string',
+              maxLength: 2000,
+              description: 'Card description (optional)',
+              example: 'Create JWT-based authentication system',
+            },
+            position: {
+              type: 'integer',
+              minimum: 0,
+              description: 'Position of card in list (for ordering)',
+              example: 0,
+            },
+            listId: {
+              type: 'string',
+              description: 'ID of the list this card belongs to',
+              example: '507f1f77bcf86cd799439011',
+            },
+            boardId: {
+              type: 'string',
+              description: 'ID of the board this card belongs to',
+              example: '507f1f77bcf86cd799439011',
+            },
+            userId: {
+              type: 'string',
+              description: 'ID of the user who owns this card',
+              example: '507f1f77bcf86cd799439011',
+            },
+            createdAt: {
+              type: 'string',
+              format: 'date-time',
+              description: 'Card creation timestamp',
+            },
+            updatedAt: {
+              type: 'string',
+              format: 'date-time',
+              description: 'Last update timestamp',
+            },
+          },
+        },
+        CardResponse: {
+          type: 'object',
+          properties: {
+            success: {
+              type: 'boolean',
+              example: true,
+            },
+            data: {
+              $ref: '#/components/schemas/Card',
+            },
+          },
+        },
+        CardsResponse: {
+          type: 'object',
+          properties: {
+            success: {
+              type: 'boolean',
+              example: true,
+            },
+            data: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/Card',
+              },
+            },
+          },
+        },
       },
     },
     tags: [
@@ -372,7 +453,7 @@ const options = {
       },
       {
         name: 'Cards',
-        description: 'Card management (coming soon)',
+        description: 'Card management endpoints',
       },
     ],
   },

--- a/server/src/controllers/__tests__/cardController.test.js
+++ b/server/src/controllers/__tests__/cardController.test.js
@@ -1,0 +1,1078 @@
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import { listCardRouter, cardRouter } from '../../routes/cardRoutes.js';
+import auth from '../../middlewares/auth.js';
+import User from '../../models/User.js';
+import Workspace from '../../models/Workspace.js';
+import Board from '../../models/Board.js';
+import List from '../../models/List.js';
+import Card from '../../models/Card.js';
+
+const app = express();
+app.use(express.json());
+app.use('/api/lists/:listId/cards', auth, listCardRouter);
+app.use('/api/cards', auth, cardRouter);
+
+describe('POST /api/lists/:listId/cards', () => {
+  let mongoServer;
+  let testUser;
+  let testWorkspace;
+  let testBoard;
+  let testList;
+  let authToken;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+    await mongoose.connect(mongoUri);
+    process.env.JWT_SECRET = 'test_secret_key';
+  }, 30000);
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+    delete process.env.JWT_SECRET;
+  });
+
+  beforeEach(async () => {
+    testUser = await User.create({
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    testWorkspace = await Workspace.create({
+      name: 'Test Workspace',
+      userId: testUser._id,
+    });
+    testBoard = await Board.create({
+      name: 'Test Board',
+      workspaceId: testWorkspace._id,
+      userId: testUser._id,
+    });
+    testList = await List.create({
+      name: 'Test List',
+      workspaceId: testWorkspace._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+      position: 0,
+    });
+    authToken = jwt.sign(
+      { id: testUser._id.toString() },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+  });
+
+  afterEach(async () => {
+    await Card.deleteMany({});
+    await List.deleteMany({});
+    await Board.deleteMany({});
+    await Workspace.deleteMany({});
+    await User.deleteMany({});
+  });
+
+  describe('Input Validation', () => {
+    it('should fail when title is missing', async () => {
+      const res = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ description: 'Some description' });
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should fail when title exceeds 200 characters', async () => {
+      const res = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: 'a'.repeat(201) });
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should fail when description exceeds 2000 characters', async () => {
+      const res = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: 'Test Card', description: 'a'.repeat(2001) });
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should fail when position is negative or non-integer', async () => {
+      const res1 = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: 'Test Card', position: -1 });
+      expect(res1.status).toBe(400);
+
+      const res2 = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: 'Test Card', position: 1.5 });
+      expect(res2.status).toBe(400);
+    });
+
+    it('should accept valid input with title only (position defaults)', async () => {
+      const res = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: 'Test Card' });
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.title).toBe('Test Card');
+      expect(res.body.data.position).toBe(0);
+    });
+
+    it('should accept valid input with title, description and position', async () => {
+      const res = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: 'Test Card', description: 'Description', position: 3 });
+      expect(res.status).toBe(201);
+      expect(res.body.data.description).toBe('Description');
+      expect(res.body.data.position).toBe(3);
+    });
+  });
+
+  describe('Authentication and List Validation', () => {
+    it('should fail without authentication token', async () => {
+      const res = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .send({ title: 'Test Card' });
+      expect(res.status).toBe(401);
+    });
+
+    it('should fail with invalid list id format', async () => {
+      const res = await request(app)
+        .post('/api/lists/invalid-id/cards')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: 'Test Card' });
+      expect(res.status).toBe(400);
+    });
+
+    it('should fail when list does not exist', async () => {
+      const fakeListId = new mongoose.Types.ObjectId();
+      const res = await request(app)
+        .post(`/api/lists/${fakeListId}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: 'Test Card' });
+      expect(res.status).toBe(404);
+    });
+
+    it('should fail when user does not own the list', async () => {
+      const otherUser = await User.create({
+        username: 'otheruser',
+        email: 'other@example.com',
+        password: 'password123',
+      });
+      const otherToken = jwt.sign(
+        { id: otherUser._id.toString() },
+        process.env.JWT_SECRET,
+        { expiresIn: '7d' }
+      );
+
+      const res = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${otherToken}`)
+        .send({ title: 'Test Card' });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('Position Management', () => {
+    it('should auto-increment position when not provided', async () => {
+      await Card.create({
+        title: 'Card 1',
+        listId: testList._id,
+        boardId: testBoard._id,
+        userId: testUser._id,
+        position: 0,
+      });
+
+      const res = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: 'Card 2' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.position).toBe(1);
+    });
+
+    it('should use provided position even if other cards exist', async () => {
+      await Card.create({
+        title: 'Card 1',
+        listId: testList._id,
+        boardId: testBoard._id,
+        userId: testUser._id,
+        position: 0,
+      });
+
+      const res = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: 'Card 2', position: 5 });
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.position).toBe(5);
+    });
+  });
+
+  describe('Card Data Integrity', () => {
+    it('should trim whitespace from title and description', async () => {
+      const res = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: '  Test Card  ', description: '  Test Description  ' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.title).toBe('Test Card');
+      expect(res.body.data.description).toBe('Test Description');
+    });
+
+    it('should store correct references (listId, boardId, userId)', async () => {
+      const res = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: 'Test Card' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.listId).toBe(testList._id.toString());
+      expect(res.body.data.boardId).toBe(testBoard._id.toString());
+      expect(res.body.data.userId).toBe(testUser._id.toString());
+    });
+
+    it('should include timestamps (createdAt, updatedAt)', async () => {
+      const res = await request(app)
+        .post(`/api/lists/${testList._id}/cards`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ title: 'Test Card' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.createdAt).toBeDefined();
+      expect(res.body.data.updatedAt).toBeDefined();
+    });
+  });
+});
+
+describe('GET /api/lists/:listId/cards', () => {
+  let mongoServer;
+  let testUser;
+  let testWorkspace;
+  let testBoard;
+  let testList;
+  let authToken;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+    await mongoose.connect(mongoUri);
+    process.env.JWT_SECRET = 'test_secret_key';
+  }, 30000);
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+    delete process.env.JWT_SECRET;
+  });
+
+  beforeEach(async () => {
+    testUser = await User.create({
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    testWorkspace = await Workspace.create({
+      name: 'Test Workspace',
+      userId: testUser._id,
+    });
+    testBoard = await Board.create({
+      name: 'Test Board',
+      workspaceId: testWorkspace._id,
+      userId: testUser._id,
+    });
+    testList = await List.create({
+      name: 'Test List',
+      workspaceId: testWorkspace._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+      position: 0,
+    });
+    authToken = jwt.sign(
+      { id: testUser._id.toString() },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+  });
+
+  afterEach(async () => {
+    await Card.deleteMany({});
+    await List.deleteMany({});
+    await Board.deleteMany({});
+    await Workspace.deleteMany({});
+    await User.deleteMany({});
+  });
+
+  it('should return empty array when list has no cards', async () => {
+    const res = await request(app)
+      .get(`/api/lists/${testList._id}/cards`)
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('should return all cards for a list sorted by position', async () => {
+    await Card.create([
+      {
+        title: 'Card 3',
+        listId: testList._id,
+        boardId: testBoard._id,
+        userId: testUser._id,
+        position: 2,
+      },
+      {
+        title: 'Card 1',
+        listId: testList._id,
+        boardId: testBoard._id,
+        userId: testUser._id,
+        position: 0,
+      },
+      {
+        title: 'Card 2',
+        listId: testList._id,
+        boardId: testBoard._id,
+        userId: testUser._id,
+        position: 1,
+      },
+    ]);
+
+    const res = await request(app)
+      .get(`/api/lists/${testList._id}/cards`)
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(3);
+    expect(res.body.data[0].title).toBe('Card 1');
+    expect(res.body.data[1].title).toBe('Card 2');
+    expect(res.body.data[2].title).toBe('Card 3');
+  });
+
+  it('should only return cards for the specified list', async () => {
+    const otherList = await List.create({
+      name: 'Other List',
+      workspaceId: testWorkspace._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+      position: 1,
+    });
+
+    await Card.create({
+      title: 'Card in Test List',
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+      position: 0,
+    });
+
+    await Card.create({
+      title: 'Card in Other List',
+      listId: otherList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+      position: 0,
+    });
+
+    const res = await request(app)
+      .get(`/api/lists/${testList._id}/cards`)
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].title).toBe('Card in Test List');
+  });
+
+  it('should fail with invalid list id format', async () => {
+    const res = await request(app)
+      .get('/api/lists/invalid-id/cards')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should fail when list does not exist', async () => {
+    const fakeListId = new mongoose.Types.ObjectId();
+    const res = await request(app)
+      .get(`/api/lists/${fakeListId}/cards`)
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('should fail when user does not own the list', async () => {
+    const otherUser = await User.create({
+      username: 'otheruser',
+      email: 'other@example.com',
+      password: 'password123',
+    });
+    const otherToken = jwt.sign(
+      { id: otherUser._id.toString() },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+
+    const res = await request(app)
+      .get(`/api/lists/${testList._id}/cards`)
+      .set('Authorization', `Bearer ${otherToken}`);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('GET /api/cards/:id', () => {
+  let mongoServer;
+  let testUser;
+  let testWorkspace;
+  let testBoard;
+  let testList;
+  let testCard;
+  let authToken;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+    await mongoose.connect(mongoUri);
+    process.env.JWT_SECRET = 'test_secret_key';
+  }, 30000);
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+    delete process.env.JWT_SECRET;
+  });
+
+  beforeEach(async () => {
+    testUser = await User.create({
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    testWorkspace = await Workspace.create({
+      name: 'Test Workspace',
+      userId: testUser._id,
+    });
+    testBoard = await Board.create({
+      name: 'Test Board',
+      workspaceId: testWorkspace._id,
+      userId: testUser._id,
+    });
+    testList = await List.create({
+      name: 'Test List',
+      workspaceId: testWorkspace._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+      position: 0,
+    });
+    testCard = await Card.create({
+      title: 'Test Card',
+      description: 'Test Description',
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+      position: 0,
+    });
+    authToken = jwt.sign(
+      { id: testUser._id.toString() },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+  });
+
+  afterEach(async () => {
+    await Card.deleteMany({});
+    await List.deleteMany({});
+    await Board.deleteMany({});
+    await Workspace.deleteMany({});
+    await User.deleteMany({});
+  });
+
+  it('should return card by id', async () => {
+    const res = await request(app)
+      .get(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.title).toBe('Test Card');
+    expect(res.body.data.description).toBe('Test Description');
+  });
+
+  it('should fail with invalid card id format', async () => {
+    const res = await request(app)
+      .get('/api/cards/invalid-id')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should fail when card does not exist', async () => {
+    const fakeCardId = new mongoose.Types.ObjectId();
+    const res = await request(app)
+      .get(`/api/cards/${fakeCardId}`)
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('should fail when user does not own the card', async () => {
+    const otherUser = await User.create({
+      username: 'otheruser',
+      email: 'other@example.com',
+      password: 'password123',
+    });
+    const otherToken = jwt.sign(
+      { id: otherUser._id.toString() },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+
+    const res = await request(app)
+      .get(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('PUT /api/cards/:id', () => {
+  let mongoServer;
+  let testUser;
+  let testWorkspace;
+  let testBoard;
+  let testList;
+  let testCard;
+  let authToken;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+    await mongoose.connect(mongoUri);
+    process.env.JWT_SECRET = 'test_secret_key';
+  }, 30000);
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+    delete process.env.JWT_SECRET;
+  });
+
+  beforeEach(async () => {
+    testUser = await User.create({
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    testWorkspace = await Workspace.create({
+      name: 'Test Workspace',
+      userId: testUser._id,
+    });
+    testBoard = await Board.create({
+      name: 'Test Board',
+      workspaceId: testWorkspace._id,
+      userId: testUser._id,
+    });
+    testList = await List.create({
+      name: 'Test List',
+      workspaceId: testWorkspace._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+      position: 0,
+    });
+    testCard = await Card.create({
+      title: 'Original Title',
+      description: 'Original Description',
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+      position: 0,
+    });
+    authToken = jwt.sign(
+      { id: testUser._id.toString() },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+  });
+
+  afterEach(async () => {
+    await Card.deleteMany({});
+    await List.deleteMany({});
+    await Board.deleteMany({});
+    await Workspace.deleteMany({});
+    await User.deleteMany({});
+  });
+
+  it('should update card title', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ title: 'Updated Title' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.title).toBe('Updated Title');
+  });
+
+  it('should update card description', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ description: 'Updated Description' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.description).toBe('Updated Description');
+  });
+
+  it('should update multiple fields at once', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ title: 'New Title', description: 'New Description' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.title).toBe('New Title');
+    expect(res.body.data.description).toBe('New Description');
+  });
+
+  it('should fail when title exceeds 200 characters', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ title: 'a'.repeat(201) });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should fail when description exceeds 2000 characters', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ description: 'a'.repeat(2001) });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should trim whitespace from updated values', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ title: '  Trimmed Title  ' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.title).toBe('Trimmed Title');
+  });
+
+  it('should fail with invalid card id format', async () => {
+    const res = await request(app)
+      .put('/api/cards/invalid-id')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ title: 'Updated Title' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should fail when card does not exist', async () => {
+    const fakeCardId = new mongoose.Types.ObjectId();
+    const res = await request(app)
+      .put(`/api/cards/${fakeCardId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ title: 'Updated Title' });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('should fail when user does not own the card', async () => {
+    const otherUser = await User.create({
+      username: 'otheruser',
+      email: 'other@example.com',
+      password: 'password123',
+    });
+    const otherToken = jwt.sign(
+      { id: otherUser._id.toString() },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+
+    const res = await request(app)
+      .put(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ title: 'Updated Title' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('should not allow updating position via PUT (use reorder endpoint)', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ position: 5 });
+
+    expect(res.status).toBe(200);
+    // Position should remain unchanged
+    expect(res.body.data.position).toBe(0);
+  });
+});
+
+describe('DELETE /api/cards/:id', () => {
+  let mongoServer;
+  let testUser;
+  let testWorkspace;
+  let testBoard;
+  let testList;
+  let testCard;
+  let authToken;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+    await mongoose.connect(mongoUri);
+    process.env.JWT_SECRET = 'test_secret_key';
+  }, 30000);
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+    delete process.env.JWT_SECRET;
+  });
+
+  beforeEach(async () => {
+    testUser = await User.create({
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    testWorkspace = await Workspace.create({
+      name: 'Test Workspace',
+      userId: testUser._id,
+    });
+    testBoard = await Board.create({
+      name: 'Test Board',
+      workspaceId: testWorkspace._id,
+      userId: testUser._id,
+    });
+    testList = await List.create({
+      name: 'Test List',
+      workspaceId: testWorkspace._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+      position: 0,
+    });
+    testCard = await Card.create({
+      title: 'Card to Delete',
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+      position: 0,
+    });
+    authToken = jwt.sign(
+      { id: testUser._id.toString() },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+  });
+
+  afterEach(async () => {
+    await Card.deleteMany({});
+    await List.deleteMany({});
+    await Board.deleteMany({});
+    await Workspace.deleteMany({});
+    await User.deleteMany({});
+  });
+
+  it('should delete card successfully', async () => {
+    const res = await request(app)
+      .delete(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toMatch(/deleted/i);
+
+    const deletedCard = await Card.findById(testCard._id);
+    expect(deletedCard).toBeNull();
+  });
+
+  it('should adjust positions of remaining cards after deletion', async () => {
+    await Card.create([
+      {
+        title: 'Card 1',
+        listId: testList._id,
+        boardId: testBoard._id,
+        userId: testUser._id,
+        position: 1,
+      },
+      {
+        title: 'Card 2',
+        listId: testList._id,
+        boardId: testBoard._id,
+        userId: testUser._id,
+        position: 2,
+      },
+    ]);
+
+    // Delete card at position 0
+    await request(app)
+      .delete(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+
+    const remainingCards = await Card.find({ listId: testList._id }).sort({
+      position: 1,
+    });
+
+    expect(remainingCards).toHaveLength(2);
+    expect(remainingCards[0].position).toBe(0);
+    expect(remainingCards[1].position).toBe(1);
+  });
+
+  it('should fail with invalid card id format', async () => {
+    const res = await request(app)
+      .delete('/api/cards/invalid-id')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should fail when card does not exist', async () => {
+    const fakeCardId = new mongoose.Types.ObjectId();
+    const res = await request(app)
+      .delete(`/api/cards/${fakeCardId}`)
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('should fail when user does not own the card', async () => {
+    const otherUser = await User.create({
+      username: 'otheruser',
+      email: 'other@example.com',
+      password: 'password123',
+    });
+    const otherToken = jwt.sign(
+      { id: otherUser._id.toString() },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+
+    const res = await request(app)
+      .delete(`/api/cards/${testCard._id}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('PUT /api/cards/:id/reorder', () => {
+  let mongoServer;
+  let testUser;
+  let testWorkspace;
+  let testBoard;
+  let testList;
+  let cards;
+  let authToken;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+    await mongoose.connect(mongoUri);
+    process.env.JWT_SECRET = 'test_secret_key';
+  }, 30000);
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+    delete process.env.JWT_SECRET;
+  });
+
+  beforeEach(async () => {
+    testUser = await User.create({
+      username: 'testuser',
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    testWorkspace = await Workspace.create({
+      name: 'Test Workspace',
+      userId: testUser._id,
+    });
+    testBoard = await Board.create({
+      name: 'Test Board',
+      workspaceId: testWorkspace._id,
+      userId: testUser._id,
+    });
+    testList = await List.create({
+      name: 'Test List',
+      workspaceId: testWorkspace._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+      position: 0,
+    });
+
+    cards = await Card.create([
+      {
+        title: 'Card 0',
+        listId: testList._id,
+        boardId: testBoard._id,
+        userId: testUser._id,
+        position: 0,
+      },
+      {
+        title: 'Card 1',
+        listId: testList._id,
+        boardId: testBoard._id,
+        userId: testUser._id,
+        position: 1,
+      },
+      {
+        title: 'Card 2',
+        listId: testList._id,
+        boardId: testBoard._id,
+        userId: testUser._id,
+        position: 2,
+      },
+    ]);
+
+    authToken = jwt.sign(
+      { id: testUser._id.toString() },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+  });
+
+  afterEach(async () => {
+    await Card.deleteMany({});
+    await List.deleteMany({});
+    await Board.deleteMany({});
+    await Workspace.deleteMany({});
+    await User.deleteMany({});
+  });
+
+  it('should reorder card to a new position', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${cards[0]._id}/reorder`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ newPosition: 2 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const reorderedCards = await Card.find({ listId: testList._id }).sort({
+      position: 1,
+    });
+
+    expect(reorderedCards[0].title).toBe('Card 1');
+    expect(reorderedCards[1].title).toBe('Card 2');
+    expect(reorderedCards[2].title).toBe('Card 0');
+  });
+
+  it('should fail when newPosition is missing', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${cards[0]._id}/reorder`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should fail when newPosition is negative', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${cards[0]._id}/reorder`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ newPosition: -1 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should fail when newPosition is not an integer', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${cards[0]._id}/reorder`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ newPosition: 1.5 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should handle moving card down (increasing position)', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${cards[0]._id}/reorder`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ newPosition: 1 });
+
+    expect(res.status).toBe(200);
+
+    const reorderedCards = await Card.find({ listId: testList._id }).sort({
+      position: 1,
+    });
+
+    expect(reorderedCards[0].title).toBe('Card 1');
+    expect(reorderedCards[1].title).toBe('Card 0');
+    expect(reorderedCards[2].title).toBe('Card 2');
+  });
+
+  it('should handle moving card up (decreasing position)', async () => {
+    const res = await request(app)
+      .put(`/api/cards/${cards[2]._id}/reorder`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ newPosition: 0 });
+
+    expect(res.status).toBe(200);
+
+    const reorderedCards = await Card.find({ listId: testList._id }).sort({
+      position: 1,
+    });
+
+    expect(reorderedCards[0].title).toBe('Card 2');
+    expect(reorderedCards[1].title).toBe('Card 0');
+    expect(reorderedCards[2].title).toBe('Card 1');
+  });
+
+  it('should fail with invalid card id format', async () => {
+    const res = await request(app)
+      .put('/api/cards/invalid-id/reorder')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ newPosition: 1 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should fail when card does not exist', async () => {
+    const fakeCardId = new mongoose.Types.ObjectId();
+    const res = await request(app)
+      .put(`/api/cards/${fakeCardId}/reorder`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ newPosition: 1 });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('should fail when user does not own the card', async () => {
+    const otherUser = await User.create({
+      username: 'otheruser',
+      email: 'other@example.com',
+      password: 'password123',
+    });
+    const otherToken = jwt.sign(
+      { id: otherUser._id.toString() },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+
+    const res = await request(app)
+      .put(`/api/cards/${cards[0]._id}/reorder`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ newPosition: 1 });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/server/src/controllers/cardController.js
+++ b/server/src/controllers/cardController.js
@@ -1,0 +1,608 @@
+import mongoose from 'mongoose';
+import Card from '../models/Card.js';
+import List from '../models/List.js';
+
+/**
+ * @swagger
+ * /api/lists/{listId}/cards:
+ *   post:
+ *     summary: Create a new card in a list
+ *     tags: [Cards]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: listId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: List ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - title
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 maxLength: 200
+ *                 example: Implement authentication
+ *               description:
+ *                 type: string
+ *                 maxLength: 2000
+ *                 example: Create JWT-based auth system
+ *               position:
+ *                 type: integer
+ *                 minimum: 0
+ *                 example: 0
+ *                 description: Position in list (auto-incremented if not provided)
+ *     responses:
+ *       201:
+ *         description: Card created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CardResponse'
+ *       400:
+ *         description: Validation error
+ *       401:
+ *         description: Not authenticated
+ *       403:
+ *         description: Not authorized to access this list
+ *       404:
+ *         description: List not found
+ *       500:
+ *         description: Server error
+ */
+/**
+ * @desc    Create new card in a list
+ * @route   POST /api/lists/:listId/cards
+ * @access  Private
+ */
+export const createCard = async (req, res) => {
+  try {
+    const { listId } = req.params;
+    const { title, description, position } = req.body;
+
+    // Validate list ID format
+    if (!mongoose.Types.ObjectId.isValid(listId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: 'Invalid list ID format' });
+    }
+
+    // Check if list exists and belongs to user
+    const list = await List.findById(listId);
+    if (!list) {
+      return res
+        .status(404)
+        .json({ success: false, message: 'List not found' });
+    }
+    if (list.userId.toString() !== req.user._id.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: 'Not authorized to access this list',
+      });
+    }
+
+    // Trim and validate title
+    const trimmedTitle = title?.trim();
+    if (!trimmedTitle) {
+      return res
+        .status(400)
+        .json({ success: false, message: 'Please provide card title' });
+    }
+    if (trimmedTitle.length > 200) {
+      return res.status(400).json({
+        success: false,
+        message: 'Card title cannot exceed 200 characters',
+      });
+    }
+
+    // Trim and validate description
+    const trimmedDescription = description?.trim();
+    if (trimmedDescription && trimmedDescription.length > 2000) {
+      return res.status(400).json({
+        success: false,
+        message: 'Description cannot exceed 2000 characters',
+      });
+    }
+
+    // Validate/derive position
+    let nextPosition = 0;
+    if (position !== undefined) {
+      if (!Number.isInteger(position) || position < 0) {
+        return res.status(400).json({
+          success: false,
+          message: 'Position must be a non-negative integer',
+        });
+      }
+      nextPosition = position;
+    } else {
+      const last = await Card.find({ listId }).sort({ position: -1 }).limit(1);
+      nextPosition = last.length ? last[0].position + 1 : 0;
+    }
+
+    const card = await Card.create({
+      title: trimmedTitle,
+      description: trimmedDescription,
+      position: nextPosition,
+      listId,
+      boardId: list.boardId,
+      userId: req.user._id,
+    });
+
+    res.status(201).json({ success: true, data: card });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * @swagger
+ * /api/lists/{listId}/cards:
+ *   get:
+ *     summary: Get all cards for a list
+ *     tags: [Cards]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: listId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: List ID
+ *     responses:
+ *       200:
+ *         description: List of cards sorted by position
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CardsResponse'
+ *       400:
+ *         description: Invalid list ID
+ *       401:
+ *         description: Not authenticated
+ *       403:
+ *         description: Not authorized to access this list
+ *       404:
+ *         description: List not found
+ *       500:
+ *         description: Server error
+ */
+/**
+ * @desc    Get all cards for a list
+ * @route   GET /api/lists/:listId/cards
+ * @access  Private
+ */
+export const getCards = async (req, res) => {
+  try {
+    const { listId } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(listId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: 'Invalid list ID format' });
+    }
+
+    const list = await List.findById(listId);
+    if (!list) {
+      return res
+        .status(404)
+        .json({ success: false, message: 'List not found' });
+    }
+    if (list.userId.toString() !== req.user._id.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: 'Not authorized to access this list',
+      });
+    }
+
+    const cards = await Card.find({ listId, userId: req.user._id }).sort({
+      position: 1,
+    });
+
+    res.status(200).json({ success: true, data: cards });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * @swagger
+ * /api/cards/{id}:
+ *   get:
+ *     summary: Get a single card by ID
+ *     tags: [Cards]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Card ID
+ *     responses:
+ *       200:
+ *         description: Card details
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CardResponse'
+ *       400:
+ *         description: Invalid card ID
+ *       401:
+ *         description: Not authenticated
+ *       403:
+ *         description: Not authorized to access this card
+ *       404:
+ *         description: Card not found
+ *       500:
+ *         description: Server error
+ */
+/**
+ * @desc    Get single card by ID
+ * @route   GET /api/cards/:id
+ * @access  Private
+ */
+export const getCard = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res
+        .status(400)
+        .json({ success: false, message: 'Invalid card ID format' });
+    }
+
+    const card = await Card.findById(id);
+    if (!card) {
+      return res
+        .status(404)
+        .json({ success: false, message: 'Card not found' });
+    }
+    if (card.userId.toString() !== req.user._id.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: 'Not authorized to access this card',
+      });
+    }
+
+    res.status(200).json({ success: true, data: card });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * @swagger
+ * /api/cards/{id}:
+ *   put:
+ *     summary: Update a card
+ *     tags: [Cards]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Card ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 maxLength: 200
+ *                 example: Updated title
+ *               description:
+ *                 type: string
+ *                 maxLength: 2000
+ *                 example: Updated description
+ *     responses:
+ *       200:
+ *         description: Card updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CardResponse'
+ *       400:
+ *         description: Validation error
+ *       401:
+ *         description: Not authenticated
+ *       403:
+ *         description: Not authorized to update this card
+ *       404:
+ *         description: Card not found
+ *       500:
+ *         description: Server error
+ */
+/**
+ * @desc    Update card
+ * @route   PUT /api/cards/:id
+ * @access  Private
+ */
+export const updateCard = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { title, description } = req.body;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res
+        .status(400)
+        .json({ success: false, message: 'Invalid card ID format' });
+    }
+
+    const card = await Card.findById(id);
+    if (!card) {
+      return res
+        .status(404)
+        .json({ success: false, message: 'Card not found' });
+    }
+    if (card.userId.toString() !== req.user._id.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: 'Not authorized to update this card',
+      });
+    }
+
+    // Update title if provided
+    if (title !== undefined) {
+      const trimmedTitle = title.trim();
+      if (!trimmedTitle) {
+        return res
+          .status(400)
+          .json({ success: false, message: 'Title cannot be empty' });
+      }
+      if (trimmedTitle.length > 200) {
+        return res.status(400).json({
+          success: false,
+          message: 'Card title cannot exceed 200 characters',
+        });
+      }
+      card.title = trimmedTitle;
+    }
+
+    // Update description if provided
+    if (description !== undefined) {
+      const trimmedDescription = description.trim();
+      if (trimmedDescription.length > 2000) {
+        return res.status(400).json({
+          success: false,
+          message: 'Description cannot exceed 2000 characters',
+        });
+      }
+      card.description = trimmedDescription;
+    }
+
+    await card.save();
+
+    res.status(200).json({ success: true, data: card });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * @swagger
+ * /api/cards/{id}:
+ *   delete:
+ *     summary: Delete a card
+ *     tags: [Cards]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Card ID
+ *     responses:
+ *       200:
+ *         description: Card deleted successfully
+ *       400:
+ *         description: Invalid card ID
+ *       401:
+ *         description: Not authenticated
+ *       403:
+ *         description: Not authorized to delete this card
+ *       404:
+ *         description: Card not found
+ *       500:
+ *         description: Server error
+ */
+/**
+ * @desc    Delete card
+ * @route   DELETE /api/cards/:id
+ * @access  Private
+ */
+export const deleteCard = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res
+        .status(400)
+        .json({ success: false, message: 'Invalid card ID format' });
+    }
+
+    const card = await Card.findById(id);
+    if (!card) {
+      return res
+        .status(404)
+        .json({ success: false, message: 'Card not found' });
+    }
+    if (card.userId.toString() !== req.user._id.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: 'Not authorized to delete this card',
+      });
+    }
+
+    const deletedPosition = card.position;
+    const listId = card.listId;
+
+    await card.deleteOne();
+
+    // Adjust positions of remaining cards
+    await Card.updateMany(
+      {
+        listId,
+        position: { $gt: deletedPosition },
+      },
+      {
+        $inc: { position: -1 },
+      }
+    );
+
+    res
+      .status(200)
+      .json({ success: true, message: 'Card deleted successfully' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+/**
+ * @swagger
+ * /api/cards/{id}/reorder:
+ *   put:
+ *     summary: Reorder a card within its list
+ *     tags: [Cards]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Card ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - newPosition
+ *             properties:
+ *               newPosition:
+ *                 type: integer
+ *                 minimum: 0
+ *                 example: 2
+ *                 description: New position index in the list
+ *     responses:
+ *       200:
+ *         description: Card reordered successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CardResponse'
+ *       400:
+ *         description: Validation error
+ *       401:
+ *         description: Not authenticated
+ *       403:
+ *         description: Not authorized to reorder this card
+ *       404:
+ *         description: Card not found
+ *       500:
+ *         description: Server error
+ */
+/**
+ * @desc    Reorder card within its list
+ * @route   PUT /api/cards/:id/reorder
+ * @access  Private
+ */
+export const reorderCard = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { newPosition } = req.body;
+
+    // Validate card ID format
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res
+        .status(400)
+        .json({ success: false, message: 'Invalid card ID format' });
+    }
+
+    // Validate newPosition
+    if (
+      newPosition === undefined ||
+      !Number.isInteger(newPosition) ||
+      newPosition < 0
+    ) {
+      return res.status(400).json({
+        success: false,
+        message: 'newPosition must be a non-negative integer',
+      });
+    }
+
+    // Find card and verify ownership
+    const card = await Card.findById(id);
+    if (!card) {
+      return res
+        .status(404)
+        .json({ success: false, message: 'Card not found' });
+    }
+    if (card.userId.toString() !== req.user._id.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: 'Not authorized to reorder this card',
+      });
+    }
+
+    const oldPosition = card.position;
+    const listId = card.listId;
+
+    // No change needed
+    if (oldPosition === newPosition) {
+      return res.status(200).json({ success: true, data: card });
+    }
+
+    // Moving card down (increasing position)
+    if (newPosition > oldPosition) {
+      await Card.updateMany(
+        {
+          listId,
+          position: { $gt: oldPosition, $lte: newPosition },
+        },
+        {
+          $inc: { position: -1 },
+        }
+      );
+    }
+    // Moving card up (decreasing position)
+    else {
+      await Card.updateMany(
+        {
+          listId,
+          position: { $gte: newPosition, $lt: oldPosition },
+        },
+        {
+          $inc: { position: 1 },
+        }
+      );
+    }
+
+    // Update card position
+    card.position = newPosition;
+    await card.save();
+
+    res.status(200).json({ success: true, data: card });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+};

--- a/server/src/controllers/listController.js
+++ b/server/src/controllers/listController.js
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
 import List from '../models/List.js';
 import Board from '../models/Board.js';
+import Card from '../models/Card.js';
 
 /**
  * @swagger
@@ -610,7 +611,8 @@ export const deleteList = async (req, res) => {
 
     await List.findByIdAndDelete(id);
 
-    // TODO: When Card model exists, cascade delete cards by listId
+    // Cascade delete: remove all cards that belong to this list
+    await Card.deleteMany({ listId: id });
 
     res
       .status(200)

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -8,6 +8,7 @@ import authRoutes from './routes/authRoutes.js';
 import workspaceRoutes from './routes/workspaceRoutes.js';
 import { workspaceBoardRouter, boardRouter } from './routes/boardRoutes.js';
 import { boardListRouter, listRouter } from './routes/listRoutes.js';
+import { listCardRouter, cardRouter } from './routes/cardRoutes.js';
 import auth from './middlewares/auth.js';
 import errorHandler from './middlewares/errorHandler.js';
 
@@ -66,10 +67,8 @@ app.use('/api/workspaces/:workspaceId/boards', auth, workspaceBoardRouter);
 app.use('/api/boards', auth, boardRouter);
 app.use('/api/boards/:boardId/lists', auth, boardListRouter);
 app.use('/api/lists', auth, listRouter);
-
-// Routes to be added next
-// import cardRoutes from './routes/cardRoutes.js';
-// app.use('/api/cards', cardRoutes);
+app.use('/api/lists/:listId/cards', auth, listCardRouter);
+app.use('/api/cards', auth, cardRouter);
 
 // 404 handler - must be before error handler
 app.use((req, res) => {

--- a/server/src/models/Card.js
+++ b/server/src/models/Card.js
@@ -1,0 +1,52 @@
+import mongoose from 'mongoose';
+
+const cardSchema = new mongoose.Schema(
+  {
+    title: {
+      type: String,
+      required: [true, 'Card title is required'],
+      maxlength: [200, 'Card title cannot exceed 200 characters'],
+      trim: true,
+    },
+    description: {
+      type: String,
+      maxlength: [2000, 'Description cannot exceed 2000 characters'],
+      trim: true,
+    },
+    position: {
+      type: Number,
+      default: 0,
+      min: [0, 'Position must be a non-negative integer'],
+      validate: {
+        validator: Number.isInteger,
+        message: 'Position must be an integer',
+      },
+    },
+    listId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'List',
+      required: [true, 'List ID is required'],
+    },
+    boardId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Board',
+      required: [true, 'Board ID is required'],
+    },
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: [true, 'User ID is required'],
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+// Useful indexes for query performance
+cardSchema.index({ listId: 1, userId: 1 });
+cardSchema.index({ listId: 1, position: 1 });
+
+const Card = mongoose.model('Card', cardSchema);
+
+export default Card;

--- a/server/src/models/__tests__/Card.test.js
+++ b/server/src/models/__tests__/Card.test.js
@@ -1,0 +1,270 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import Card from '../Card.js';
+import List from '../List.js';
+import Board from '../Board.js';
+import Workspace from '../Workspace.js';
+import User from '../User.js';
+
+let mongoServer;
+let testUser;
+let testWorkspace;
+let testBoard;
+let testList;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+  await mongoose.connect(mongoUri);
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  testUser = await User.create({
+    username: 'testuser',
+    email: 'test@example.com',
+    password: 'password123',
+  });
+
+  testWorkspace = await Workspace.create({
+    name: 'Test Workspace',
+    userId: testUser._id,
+  });
+
+  testBoard = await Board.create({
+    name: 'Test Board',
+    workspaceId: testWorkspace._id,
+    userId: testUser._id,
+  });
+
+  testList = await List.create({
+    name: 'Test List',
+    workspaceId: testWorkspace._id,
+    boardId: testBoard._id,
+    userId: testUser._id,
+    position: 0,
+  });
+});
+
+afterEach(async () => {
+  await Card.deleteMany({});
+  await List.deleteMany({});
+  await Board.deleteMany({});
+  await Workspace.deleteMany({});
+  await User.deleteMany({});
+});
+
+describe('Card Model - Schema Validation', () => {
+  it('should create a valid card with all required fields', async () => {
+    const card = await Card.create({
+      title: 'Implement login',
+      description: 'Create JWT-based authentication',
+      position: 0,
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    expect(card.title).toBe('Implement login');
+    expect(card.description).toBe('Create JWT-based authentication');
+    expect(card.position).toBe(0);
+    expect(card.listId.toString()).toBe(testList._id.toString());
+    expect(card.boardId.toString()).toBe(testBoard._id.toString());
+    expect(card.userId.toString()).toBe(testUser._id.toString());
+    expect(card.createdAt).toBeDefined();
+    expect(card.updatedAt).toBeDefined();
+  });
+
+  it('should default position to 0 when not provided', async () => {
+    const card = await Card.create({
+      title: 'Fix bug',
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    expect(card.position).toBe(0);
+  });
+
+  it('should fail validation when title is missing', async () => {
+    const card = new Card({
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    await expect(card.save()).rejects.toThrow();
+  });
+
+  it('should fail validation when listId is missing', async () => {
+    const card = new Card({
+      title: 'Test Card',
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    await expect(card.save()).rejects.toThrow();
+  });
+
+  it('should fail validation when boardId is missing', async () => {
+    const card = new Card({
+      title: 'Test Card',
+      listId: testList._id,
+      userId: testUser._id,
+    });
+
+    await expect(card.save()).rejects.toThrow();
+  });
+
+  it('should fail validation when userId is missing', async () => {
+    const card = new Card({
+      title: 'Test Card',
+      listId: testList._id,
+      boardId: testBoard._id,
+    });
+
+    await expect(card.save()).rejects.toThrow();
+  });
+
+  it('should trim whitespace from title', async () => {
+    const card = await Card.create({
+      title: '  Implement feature  ',
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    expect(card.title).toBe('Implement feature');
+  });
+
+  it('should trim whitespace from description', async () => {
+    const card = await Card.create({
+      title: 'Test Card',
+      description: '  Some description  ',
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    expect(card.description).toBe('Some description');
+  });
+
+  it('should enforce maximum length on title', async () => {
+    const longTitle = 'a'.repeat(201);
+    const card = new Card({
+      title: longTitle,
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    await expect(card.save()).rejects.toThrow();
+  });
+
+  it('should enforce maximum length on description', async () => {
+    const longDescription = 'a'.repeat(2001);
+    const card = new Card({
+      title: 'Test Card',
+      description: longDescription,
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    await expect(card.save()).rejects.toThrow();
+  });
+
+  it('should require position to be a non-negative integer', async () => {
+    const card = new Card({
+      title: 'Test Card',
+      position: -1,
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    await expect(card.save()).rejects.toThrow();
+  });
+
+  it('should require position to be an integer', async () => {
+    const card = new Card({
+      title: 'Test Card',
+      position: 3.14,
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    await expect(card.save()).rejects.toThrow();
+  });
+
+  it('should allow description to be optional', async () => {
+    const card = await Card.create({
+      title: 'Simple Card',
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    expect(card.description).toBeUndefined();
+  });
+});
+
+describe('Card Model - Indexes', () => {
+  it('should have an index on listId and userId', async () => {
+    const indexes = Card.schema.indexes();
+    const hasListUserIndex = indexes.some(
+      index => index[0].listId === 1 && index[0].userId === 1
+    );
+
+    expect(hasListUserIndex).toBe(true);
+  });
+
+  it('should have an index on listId and position', async () => {
+    const indexes = Card.schema.indexes();
+    const hasListPositionIndex = indexes.some(
+      index => index[0].listId === 1 && index[0].position === 1
+    );
+
+    expect(hasListPositionIndex).toBe(true);
+  });
+});
+
+describe('Card Model - Timestamps', () => {
+  it('should have createdAt and updatedAt timestamps', async () => {
+    const card = await Card.create({
+      title: 'Timestamped Card',
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    expect(card.createdAt).toBeInstanceOf(Date);
+    expect(card.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('should update updatedAt timestamp when card is modified', async () => {
+    const card = await Card.create({
+      title: 'Original Title',
+      listId: testList._id,
+      boardId: testBoard._id,
+      userId: testUser._id,
+    });
+
+    const originalUpdatedAt = card.updatedAt;
+
+    // Wait a moment to ensure timestamp difference
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    card.title = 'Updated Title';
+    await card.save();
+
+    expect(card.updatedAt.getTime()).toBeGreaterThan(
+      originalUpdatedAt.getTime()
+    );
+  });
+});

--- a/server/src/routes/cardRoutes.js
+++ b/server/src/routes/cardRoutes.js
@@ -1,0 +1,24 @@
+import express from 'express';
+import {
+  createCard,
+  getCards,
+  getCard,
+  updateCard,
+  reorderCard,
+  deleteCard,
+} from '../controllers/cardController.js';
+
+const listCardRouter = express.Router({ mergeParams: true });
+const cardRouter = express.Router();
+
+// Routes for /api/lists/:listId/cards
+listCardRouter.post('/', createCard);
+listCardRouter.get('/', getCards);
+
+// Routes for /api/cards/:id
+cardRouter.get('/:id', getCard);
+cardRouter.put('/:id', updateCard);
+cardRouter.put('/:id/reorder', reorderCard);
+cardRouter.delete('/:id', deleteCard);
+
+export { listCardRouter, cardRouter };


### PR DESCRIPTION
## Description
This PR implements the complete Card CRUD functionality following strict TDD principles.

## Changes
- ✅ **Card Model** (`Card.js`): Mongoose schema with validation for title, description, position, listId, boardId, userId
- ✅ **Card Controller** (`cardController.js`): Full CRUD operations + reorder endpoint
  - `POST /api/lists/:listId/cards` - Create card in list
  - `GET /api/lists/:listId/cards` - Get all cards for list (sorted by position)
  - `GET /api/cards/:id` - Get single card
  - `PUT /api/cards/:id` - Update card (title, description)
  - `DELETE /api/cards/:id` - Delete card with position adjustment
  - `PUT /api/cards/:id/reorder` - Reorder card within list
- ✅ **Cascade Delete**: List deletion now removes all associated cards
- ✅ **Tests**: 66 new tests (17 model + 49 controller) - all passing ✅
- ✅ **Swagger Documentation**: Full OpenAPI specs for Card endpoints
- ✅ **TDD Documentation**: Added comprehensive TDD workflow to copilot instructions

## TDD Approach
✅ Red-Green-Refactor cycle followed strictly:
1. Wrote model tests → FAILED → Implemented model → PASSED
2. Wrote controller tests → FAILED → Implemented controller → PASSED

## Test Results
```
Test Suites: 11 passed, 11 total
Tests:       304 passed, 304 total
```

## Issues Closed
Closes #18, Closes #19, Closes #57, Closes #58

## Checklist
- [x] Tests passing locally (304/304 tests)
- [x] ESLint passing
- [x] Prettier formatting applied
- [x] Swagger documentation added
- [x] Cascade delete implemented
- [x] Conventional commit message
- [x] PR targets `dev` branch (GitFlow)
