### PR TITLE
release: fix HTTP/socket race duplicates for lists and comments

### DIFF
--- a/client/src/components/CommentSection.jsx
+++ b/client/src/components/CommentSection.jsx
@@ -68,7 +68,12 @@ const CommentSection = ({ cardId, workspaceId, commentEvent }) => {
   const handleAddComment = async content => {
     const response = await commentAPI.create(cardId, { content });
     const newComment = response.data.data;
-    setComments(prev => [...prev, newComment]);
+    setComments(prev => {
+      // Deduplicate: socket (commentEvent) may have already added this comment
+      // if comment:created arrived before the HTTP response
+      if (prev.some(c => c._id === newComment._id)) return prev;
+      return [...prev, newComment];
+    });
   };
 
   const handleEditComment = async (commentId, content) => {


### PR DESCRIPTION
## À merger après la PR #165

Contient :
- **fix(list)** : dédup par `_id` dans `handleListCreated` + `handleCreateList` (race condition HTTP/socket)
- **fix(comments)** : dédup par `_id` dans `handleAddComment` (même race condition)

> Merger d'abord PR #165 (`fix/list-duplicate-dedup → dev`) pour que ce PR inclue les deux fixes.